### PR TITLE
Add settings to modify program fonts and font sizes

### DIFF
--- a/LyricEditor/App.config
+++ b/LyricEditor/App.config
@@ -11,6 +11,10 @@
     <add key="ShortTimeShift" value="2" />
     <add key="LongTimeShift" value="5" />
     <add key="ClientSettingsProvider.ServiceUri" value="" />
+	<!--字体配置    请使用系统字体名称。
+	Windows下可以到"C:\Windows\Fonts"中查看，显示的名称即字体名称。-->
+	<add key="LyricFont" value="隶书 常规"/>
+	<add key="LyricFontSize" value="18"/>
   </appSettings>
   <system.web>
     <membership defaultProvider="ClientAuthenticationMembershipProvider">

--- a/LyricEditor/App.config
+++ b/LyricEditor/App.config
@@ -13,8 +13,8 @@
     <add key="ClientSettingsProvider.ServiceUri" value="" />
 	<!--字体配置    请使用系统字体名称。
 	Windows下可以到"C:\Windows\Fonts"中查看，显示的名称即字体名称。-->
-	<add key="LyricFont" value="隶书 常规"/>
-	<add key="LyricFontSize" value="18"/>
+	<add key="LyricFont" value="宋体 常规"/>
+	<add key="LyricFontSize" value="16"/>
   </appSettings>
   <system.web>
     <membership defaultProvider="ClientAuthenticationMembershipProvider">

--- a/LyricEditor/App.xaml.cs
+++ b/LyricEditor/App.xaml.cs
@@ -1,5 +1,8 @@
-﻿using System.Text;
+﻿using System;
+using System.Configuration;
+using System.Text;
 using System.Windows;
+using System.Windows.Media;
 
 namespace LyricEditor
 {
@@ -8,6 +11,21 @@ namespace LyricEditor
         public App()
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+
+            // 先读取配置文件，再启动主窗口
+            ResourceDictionary resourceDictionary = new ResourceDictionary();
+            // 读取字体：
+            String fontName = ConfigurationManager.AppSettings["LyricFont"];
+            resourceDictionary.Add("LyricFont", new FontFamily(fontName));
+            // 读取字体大小：
+            Double fontSize = Double.Parse(ConfigurationManager.AppSettings["LyricFontSize"]);
+            resourceDictionary.Add("LyricFontSize", fontSize);
+            this.Resources.MergedDictionaries.Add(resourceDictionary);
         }
     }
 }

--- a/LyricEditor/MainWindow.xaml
+++ b/LyricEditor/MainWindow.xaml
@@ -320,7 +320,7 @@
         <Grid Grid.Column="1" Margin="5">
             <Grid.Resources>
                 <Style TargetType="TextBlock">
-                    <Setter Property="FontSize" Value="16" />
+                    <Setter Property="FontSize" Value="{StaticResource LyricFontSize}" />
                     <Setter Property="VerticalAlignment" Value="Center" />
                 </Style>
             </Grid.Resources>

--- a/LyricEditor/Styles/Styles.xaml
+++ b/LyricEditor/Styles/Styles.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:local="clr-namespace:LyricEditor">
+                    xmlns:local="clr-namespace:LyricEditor" xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="Colors.xaml" />
@@ -10,12 +10,13 @@
         <Setter Property="FontFamily" Value="Microsoft YaHei UI" />
     </Style>
 
-    <!-- 歌词字体 -->
+    <!-- 默认-字体 -->
     <FontFamily x:Key="LyricFont">Microsoft Yahei UI</FontFamily>
+    <system:Double x:Key="LyricFontSize">16</system:Double>
 
     <!-- 左上菜单栏标题按钮的样式 -->
     <Style x:Key="MenuItemHeaderStyle" TargetType="MenuItem">
-        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontSize" Value="{StaticResource LyricFontSize}" />
         <Setter Property="Background" Value="White" />
         <Setter Property="Height" Value="30" />
         <Setter Property="BorderThickness" Value="0" />
@@ -134,7 +135,7 @@
     </Style>
     <!-- 左上菜单栏二级按钮的样式 -->
     <Style x:Key="SubMenuItemHeaderStyle" TargetType="MenuItem">
-        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontSize" Value="{StaticResource LyricFontSize}" />
         <Setter Property="Height" Value="30" />
         <Setter Property="Template">
             <Setter.Value>

--- a/LyricEditor/UserControls/InputBox.xaml
+++ b/LyricEditor/UserControls/InputBox.xaml
@@ -5,10 +5,11 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:LyricEditor.UserControls"
         Title="输入窗口"
-        Width="250"
+        Width="Auto"
+        MinWidth="250"
         SizeToContent="Height"
         WindowStartupLocation="CenterOwner"
-        FontSize="16"
+        FontSize="{StaticResource LyricFontSize}"
         WindowStyle="ToolWindow"
         mc:Ignorable="d">
     <StackPanel>

--- a/LyricEditor/UserControls/LrcLineView.xaml
+++ b/LyricEditor/UserControls/LrcLineView.xaml
@@ -18,7 +18,7 @@
                   Margin="0"
                   x:FieldModifier="public"
                   BorderThickness="1,1,1,0"
-                  FontSize="16"
+                  FontSize="{StaticResource LyricFontSize}"
                   SelectionMode="Single"
                   MouseDoubleClick="LrcLinePanel_MouseDoubleClick"
                   KeyUp="LrcLinePanel_KeyUp"
@@ -28,7 +28,7 @@
                 <DataTemplate>
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="80" />
+                            <ColumnDefinition Width="Auto" MinWidth="80"/>
                             <ColumnDefinition Width="10" />
                             <ColumnDefinition />
                         </Grid.ColumnDefinitions>
@@ -56,13 +56,14 @@
         <DockPanel Grid.Row="1">
             <DockPanel.Resources>
                 <Style TargetType="TextBox">
-                    <Setter Property="FontSize" Value="16" />
+                    <Setter Property="FontSize" Value="{StaticResource LyricFontSize}" />
                     <Setter Property="VerticalContentAlignment" Value="Center" />
                     <Setter Property="FontFamily" Value="{StaticResource LyricFont}" />
                 </Style>
             </DockPanel.Resources>
             <TextBox Name="CurrentTimeText"
-                     Width="93"
+                     Width="Auto"
+                     MinWidth="93"
                      Padding="7,0,0,0"
                      HorizontalContentAlignment="Left"
                      DockPanel.Dock="Left"

--- a/LyricEditor/UserControls/LrcTextView.xaml
+++ b/LyricEditor/UserControls/LrcTextView.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:LyricEditor.UserControls"
              xmlns:conv="clr-namespace:LyricEditor.Converters"
              mc:Ignorable="d" 
-             FontSize="16"
+             FontSize="{StaticResource LyricFontSize}"
              FontFamily="{StaticResource LyricFont}"
              d:DesignHeight="300" d:DesignWidth="300">
     <UserControl.Resources>


### PR DESCRIPTION
## Pr的修改内容/Modified content

1. 添加设置以修改程序字体和字体大小/Add settings to modify program fonts and font sizes.
2. 修改 `App.config` 文件的默认配置/Modify the default configuration.


## 说明

由于一些特殊需求，编辑歌词时可能会用到一些Unicode CJKV的字符，默认的 `Microsoft Yahei UI` 字体无法显示对应的字符，故添加 `LyricFont` 的配置项到 `App.config` 中。顺便，添加了 `LyricFontSize` 。